### PR TITLE
Fixed react native dependency Issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     "read sms",
     "android sms"
   ],
-  "author": "Abhishek Jain",
+  "author": "Abhishek Jain", 
   "license": "MIT",
   "peerDependencies": {
-    "react-native": "^0.41.2"
+    "react-native": "^0.70.5"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Because the expo app crashes due to a dependency issue while building, the latest version of RN has been used to keep it in sync with the other versions.