### PR TITLE
 Add sms originator information to callback #20 

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You may refer to this sample application for how to use the library: [GitHub Rep
 |-------------|-------------|--------|---------|
 | `checkIfHasSMSPermission` | Function which checks if the application has `READ_SMS` and `RECEIVE_SMS` permissions | - | ```{ hasReceiveSmsPermission: true/false, hasReadSmsPermission: true/false }``` |
 | `requestReadSMSPermission` | Requests `READ_SMS` and `RECEIVE_SMS` permission, if missing | - | Returns `true` if granted, and `false` otherwise |
-| `startReadSMS` | Starts listening for incoming messages. Note: SMS Permissions should be present. | callback fn | Incoming message body |
+| `startReadSMS` | Starts listening for incoming messages. Note: SMS Permissions should be present. | callback fn | Return a string with message orginating address, and message body. Example: `[+919999999999, this is a sample message body]` |
 
 
 ### Important Note:

--- a/android/src/main/java/com/reactlibrary/RNExpoReadSmsModule.java
+++ b/android/src/main/java/com/reactlibrary/RNExpoReadSmsModule.java
@@ -88,8 +88,6 @@ public class RNExpoReadSmsModule extends ReactContextBaseJavaModule {
             SmsMessage currentMessage = SmsMessage.createFromPdu((byte[]) aPdusObj);
             SMSReturnValues[0] = currentMessage.getDisplayOriginatingAddress();
             SMSReturnValues[1] = currentMessage.getDisplayMessageBody();
-            byte currentMessageUserData [] = currentMessage.getUserData();
-            Log.i("ReadSMSModule", "SMS useData is:"+new String(currentMessageUserData, "UTF-8"));
           }
         }
       }

--- a/android/src/main/java/com/reactlibrary/RNExpoReadSmsModule.java
+++ b/android/src/main/java/com/reactlibrary/RNExpoReadSmsModule.java
@@ -72,21 +72,33 @@ public class RNExpoReadSmsModule extends ReactContextBaseJavaModule {
 
   private String getMessageFromMessageIntent(Intent intent) {
     final Bundle bundle = intent.getExtras();
-    String message = "";
+    
+    /*
+      Index 0 - to have originating Address
+      Index 1 - to have message body
+    */
+
+    String SMSReturnValues = new String [2];
+    String currentMessageUserData = "";
+
     try {
       if (bundle != null) {
         final Object[] pdusObj = (Object[]) bundle.get("pdus");
         if (pdusObj != null) {
           for (Object aPdusObj : pdusObj) {
             SmsMessage currentMessage = SmsMessage.createFromPdu((byte[]) aPdusObj);
-            message = currentMessage.getDisplayMessageBody();
+            SMSReturnValues[0] = currentMessage.getDisplayOriginatingAddress();
+            SMSReturnValues[1] = currentMessage.getDisplayMessageBody();
+            currentMessageUserData = currentMessage.getUserData();
           }
         }
       }
-      Log.i("ReadSMSModule", "SMS received is:"+message);
+      Log.i("ReadSMSModule", "SMS Originating Address received is:"+SMSReturnValues[0]);
+      Log.i("ReadSMSModule", "SMS received is:"+SMSReturnValues[1]);
+      Log.i("ReadSMSModule", "SMS useData is:"+new String(currentMessageUserData, "UTF-8"))
     } catch (Exception e) {
       e.printStackTrace();
     }
-    return message;
+    return SMSReturnValues;
   }
 }

--- a/android/src/main/java/com/reactlibrary/RNExpoReadSmsModule.java
+++ b/android/src/main/java/com/reactlibrary/RNExpoReadSmsModule.java
@@ -19,6 +19,8 @@ import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 
+import java.util.Arrays;
+
 public class RNExpoReadSmsModule extends ReactContextBaseJavaModule {
 
   private final ReactApplicationContext reactContext;
@@ -70,7 +72,7 @@ public class RNExpoReadSmsModule extends ReactContextBaseJavaModule {
     }
   }
 
-  private String [] getMessageFromMessageIntent(Intent intent) {
+  private String getMessageFromMessageIntent(Intent intent) {
     final Bundle bundle = intent.getExtras();
     
     /*
@@ -96,6 +98,8 @@ public class RNExpoReadSmsModule extends ReactContextBaseJavaModule {
     } catch (Exception e) {
       e.printStackTrace();
     }
-    return SMSReturnValues;
+
+    final String finalSMSReturnValues = Arrays.toString(SMSReturnValues);
+    return finalSMSReturnValues;
   }
 }

--- a/android/src/main/java/com/reactlibrary/RNExpoReadSmsModule.java
+++ b/android/src/main/java/com/reactlibrary/RNExpoReadSmsModule.java
@@ -95,7 +95,7 @@ public class RNExpoReadSmsModule extends ReactContextBaseJavaModule {
       }
       Log.i("ReadSMSModule", "SMS Originating Address received is:"+SMSReturnValues[0]);
       Log.i("ReadSMSModule", "SMS received is:"+SMSReturnValues[1]);
-      Log.i("ReadSMSModule", "SMS useData is:"+new String(currentMessageUserData, "UTF-8"))
+      Log.i("ReadSMSModule", "SMS useData is:"+new String(currentMessageUserData, "UTF-8"));
     } catch (Exception e) {
       e.printStackTrace();
     }

--- a/android/src/main/java/com/reactlibrary/RNExpoReadSmsModule.java
+++ b/android/src/main/java/com/reactlibrary/RNExpoReadSmsModule.java
@@ -70,7 +70,7 @@ public class RNExpoReadSmsModule extends ReactContextBaseJavaModule {
     }
   }
 
-  private String getMessageFromMessageIntent(Intent intent) {
+  private String [] getMessageFromMessageIntent(Intent intent) {
     final Bundle bundle = intent.getExtras();
     
     /*
@@ -78,8 +78,7 @@ public class RNExpoReadSmsModule extends ReactContextBaseJavaModule {
       Index 1 - to have message body
     */
 
-    String SMSReturnValues = new String [2];
-    String currentMessageUserData = "";
+    String SMSReturnValues [] = new String [2];
 
     try {
       if (bundle != null) {
@@ -89,13 +88,13 @@ public class RNExpoReadSmsModule extends ReactContextBaseJavaModule {
             SmsMessage currentMessage = SmsMessage.createFromPdu((byte[]) aPdusObj);
             SMSReturnValues[0] = currentMessage.getDisplayOriginatingAddress();
             SMSReturnValues[1] = currentMessage.getDisplayMessageBody();
-            currentMessageUserData = currentMessage.getUserData();
+            byte currentMessageUserData [] = currentMessage.getUserData();
+            Log.i("ReadSMSModule", "SMS useData is:"+new String(currentMessageUserData, "UTF-8"));
           }
         }
       }
       Log.i("ReadSMSModule", "SMS Originating Address received is:"+SMSReturnValues[0]);
       Log.i("ReadSMSModule", "SMS received is:"+SMSReturnValues[1]);
-      Log.i("ReadSMSModule", "SMS useData is:"+new String(currentMessageUserData, "UTF-8"));
     } catch (Exception e) {
       e.printStackTrace();
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maniac-tech/react-native-expo-read-sms",
-  "version": "1.0.13",
+  "version": "1.1",
   "description": "Library to read incoming SMS in Android for Expo (React Native)",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "Abhishek Jain",
   "license": "MIT",
   "peerDependencies": {
-    "react-native": "^0.41.2"
+    "react-native": "^0.68.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Description

- Return sms originator body, along with sms message body.
- Update the peer dependency to `0.68.2`

### Fixes:
- #20 
- #19 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update