### PR TITLE
fix: loosen peer dependency version constraint for `react-native`

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "Abhishek Jain",
   "license": "MIT",
   "peerDependencies": {
-    "react-native": "0.74.3"
+    "react-native": "*"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Description

The version isn't compatible with newer versions of `react-native` due to the hardcoded version of the peer dependency. This PR adds a `*` as a catch-all, allowing it to adapt to the parent project's version.

### Fixes #91 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
