### PR TITLE
fix: override transitive fast-xml-parser to patch entity encoding bypass (GHSA-m7jm-9gc2-mpf2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4019,19 +4019,16 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.0.tgz",
-      "integrity": "sha512-/PlTQCI96+fZMAOLMZK4CWG1ItCbfZ/0jx7UIJFChPNrx7tcEgerUgWbeieCM9MfHInUDyK8DWYZ+YrywDJuTg==",
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.7.tgz",
+      "integrity": "sha512-a6Qh1RMCNbSrU1+sAyAAZH3rTe+OaWJbNZIq0S+ifZciUUOQtlVxBJwoTUE2bYhysmG/RYyI5WJFIKdBahJdrQ==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
         }
       ],
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "strnum": "^1.0.5"
@@ -9256,7 +9253,7 @@
         "chalk": "^4.1.2",
         "execa": "^5.0.0",
         "fast-glob": "^3.3.2",
-        "fast-xml-parser": "^4.2.4",
+        "fast-xml-parser": "^4.5.4",
         "logkitty": "^0.7.1"
       }
     },
@@ -9270,7 +9267,7 @@
         "chalk": "^4.1.2",
         "execa": "^5.0.0",
         "fast-glob": "^3.3.2",
-        "fast-xml-parser": "^4.0.12",
+        "fast-xml-parser": "^4.5.4",
         "ora": "^5.4.1"
       }
     },
@@ -10423,9 +10420,9 @@
       }
     },
     "fast-xml-parser": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.0.tgz",
-      "integrity": "sha512-/PlTQCI96+fZMAOLMZK4CWG1ItCbfZ/0jx7UIJFChPNrx7tcEgerUgWbeieCM9MfHInUDyK8DWYZ+YrywDJuTg==",
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.7.tgz",
+      "integrity": "sha512-a6Qh1RMCNbSrU1+sAyAAZH3rTe+OaWJbNZIq0S+ifZciUUOQtlVxBJwoTUE2bYhysmG/RYyI5WJFIKdBahJdrQ==",
       "peer": true,
       "requires": {
         "strnum": "^1.0.5"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "url": "https://github.com/maniac-tech/react-native-expo-read-sms.git"
   },
   "overrides": {
-    "shell-quote": "^1.8.4"
+    "shell-quote": "^1.8.4",
+    "fast-xml-parser": "^4.5.4"
   }
 }


### PR DESCRIPTION
## Summary
- Fixes [Dependabot alert #35](https://github.com/maniac-tech/react-native-expo-read-sms/security/dependabot/35): `fast-xml-parser` < 4.5.4 is vulnerable to CVE-2026-25896 (critical, CVSS 9.3), an entity-encoding bypass where a DOCTYPE entity name containing a `.` is treated as a regex wildcard, allowing built-in entities (`&lt;` `&gt;` `&amp;` `&quot;` `&apos;`) to be shadowed with attacker-controlled values — leading to XSS/injection when parsed XML output is rendered.
- `fast-xml-parser` is a transitive dependency pulled in via `@react-native-community/cli-platform-android` and `cli-platform-apple` (both peer deps), currently resolving to the vulnerable 4.5.0.
- Adds an `overrides` entry (following the existing pattern used for `shell-quote`) to force `fast-xml-parser@^4.5.4`, which resolves to the latest patched 4.x release (4.5.7).

## Test plan
- [x] `npm install` succeeds with the override and `package-lock.json` resolves `fast-xml-parser` to 4.5.7 everywhere
- [x] Diff limited to `package.json` / `package-lock.json`, no other packages affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)