### PR TITLE
fix: concatenate multi-part SMS bodies instead of overwriting

### DIFF
--- a/android/src/main/java/com/reactlibrary/RNExpoReadSmsModule.java
+++ b/android/src/main/java/com/reactlibrary/RNExpoReadSmsModule.java
@@ -97,11 +97,14 @@ public class RNExpoReadSmsModule extends ReactContextBaseJavaModule {
       if (bundle != null) {
         final Object[] pdusObj = (Object[]) bundle.get("pdus");
         if (pdusObj != null) {
+          String format = bundle.getString("format");
+          StringBuilder messageBody = new StringBuilder();
           for (Object aPdusObj : pdusObj) {
-            SmsMessage currentMessage = SmsMessage.createFromPdu((byte[]) aPdusObj);
+            SmsMessage currentMessage = SmsMessage.createFromPdu((byte[]) aPdusObj, format);
             SMSReturnValues[0] = currentMessage.getDisplayOriginatingAddress();
-            SMSReturnValues[1] = currentMessage.getDisplayMessageBody();
+            messageBody.append(currentMessage.getDisplayMessageBody());
           }
+          SMSReturnValues[1] = messageBody.toString();
         }
       }
       Log.i("ReadSMSModule", "SMS Originating Address: " + SMSReturnValues[0]);


### PR DESCRIPTION
## Summary
- Long messages (especially UCS-2 encoded ones, which max out at 70 chars per segment vs 160 for GSM-7) are delivered as multiple PDUs. The `onReceive` handler was overwriting the message body with each PDU instead of appending, so only the last segment was ever returned to JS.
- Also pass the `format` extra into `SmsMessage.createFromPdu` so each segment is decoded with the correct format (available since minSdk 23).

Fixes #101

## Test plan
- [ ] Send a multi-segment UCS-2 SMS (e.g. one containing an emoji, long enough to split into multiple PDUs) and confirm `startReadSMS`'s callback returns the full message body, not just the final segment.
- [ ] Send a normal single-segment GSM-7 SMS and confirm it's unaffected.